### PR TITLE
fix: update CSP in vercel.json to allow inline scripts and data URIs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self' wss: *.hotjar.com *.googleapis.com https://www.google-analytics.com *.gstatic.com  *.fontawesome.com; style-src 'self' 'unsafe-inline' *.fontawesome.com *.googleapis.com;"
+          "value": "default-src 'self' wss: *.hotjar.com *.googleapis.com https://www.google-analytics.com *.gstatic.com  *.fontawesome.com; script-src 'self' 'unsafe-inline' wss: *.hotjar.com *.googleapis.com https://www.google-analytics.com *.gstatic.com *.fontawesome.com; style-src 'self' 'unsafe-inline' *.fontawesome.com *.googleapis.com; img-src 'self' data: i.scdn.co;"
         }
       ]
     }


### PR DESCRIPTION
- Added 'unsafe-inline' to script-src in CSP to allow next-themes and Next.js internal scripts to execute.
- Added 'data:' to img-src to allow blurred image placeholders.
- Added 'i.scdn.co' to img-src to allow Spotify images.
- This fixes the dark mode toggle and missing footer icons on the deployed site.

TAG=agy
CONV=586bbb20-86c3-4133-95f8-0fe0d48f884a